### PR TITLE
fix: update checkpoint threshold for API request management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # C extensions
 *.so
 .cursor/*
+*.psd
 
 # Distribution / packaging
 .Python

--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ DEFAULT_CONFIG: Configuration = {
     "ANALYZE_CLONES": False,  # Whether to clone repos for deeper analysis
     "ENABLE_CHECKPOINTING": True,  # Whether to enable checkpoint feature
     "CHECKPOINT_FILE": "github_analyzer_checkpoint.pkl",  # Checkpoint file location
-    "CHECKPOINT_THRESHOLD": 4280,  # Create checkpoint when remaining API requests falls below this
+    "CHECKPOINT_THRESHOLD": 100,  # Create checkpoint when remaining API requests falls below this
     "RESUME_FROM_CHECKPOINT": True,  # Whether to resume from checkpoint if it exists
 }
 


### PR DESCRIPTION
- Changed the CHECKPOINT_THRESHOLD value in the configuration from 4280 to 100 to ensure timely checkpoint creation when remaining API requests fall below this threshold.
- This adjustment aims to enhance the application's ability to manage API request limits effectively.